### PR TITLE
Fix Laravel 13 PHPStan error and flaky import command test

### DIFF
--- a/src/Services/GeographyUpdateService.php
+++ b/src/Services/GeographyUpdateService.php
@@ -139,7 +139,10 @@ final class GeographyUpdateService
                 ->find($id);
 
             if ($record !== null) {
-                $record->update($updateData);
+                foreach ($updateData as $field => $value) {
+                    $record->setAttribute((string) $field, $value);
+                }
+                $record->save();
                 $count++;
             }
         }

--- a/tests/Feature/Commands/ImportCommandTest.php
+++ b/tests/Feature/Commands/ImportCommandTest.php
@@ -1,10 +1,18 @@
 <?php
 
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
 use PlinCode\IstatGeography\Models\Geography\Municipality;
 use PlinCode\IstatGeography\Models\Geography\Province;
 use PlinCode\IstatGeography\Models\Geography\Region;
 
 test('import command imports all geographical data', function () {
+    $csvHeader = 'Codice Regione;Col1;Codice Provincia (Storico);Col3;Codice Comune formato alfanumerico;Denominazione (Italiana e straniera);Denominazione italiano;Denominazione altra lingua;Col8;Col9;Denominazione Regione;Denominazione Provincia;Col12;Col13;Sigla automobilistica;Col15;Col16;Col17;Col18;Codice Catastale del comune;Col20;Col21;Col22;Col23';
+    $csvRow = '01;001;001;001;010001;AGLIÈ;Agliè;;1;Nord-ovest;Piemonte;Torino;0;0;TO;010001;010001;010001;010001;A074;ITC;ITC1;ITC11;ITC';
+
+    Http::fake(['*' => Http::response($csvHeader."\n".$csvRow, 200)]);
+    Storage::disk('local')->delete('istat_municipalities.csv');
+
     $this->artisan('geography:import')
         ->assertSuccessful();
 


### PR DESCRIPTION
## What

Two fixes to get `main` green again on CI (PHPStan job and the test matrix).

### 1. PHPStan error under Laravel 13

`GeographyUpdateService::updateModifiedRecords()` called `$record->update($updateData)` where `$record` is a `Region|Province|Municipality` union. On Laravel 13 `Model::update()` is typed `array<model property, mixed>`, and the dynamically keyed `$updateData` does not satisfy the per model property generic, so larastan reports `argument.type`.

The fix applies the changes through `setAttribute()` followed by `save()`. Same runtime behavior (model events and timestamps preserved), no static analysis error.

### 2. Flaky import command test

`ImportCommandTest` was the only command test without an HTTP fake. It relied on a real ISTAT download (or a cached CSV left behind by another test), so it failed intermittently in CI with `Failed asserting that 0 is greater than 0`. It now fakes the HTTP response and clears the cached CSV, matching the pattern already used by the other command tests.

## Verification

Reproduced the PHPStan failure locally against Laravel 13, confirmed the fix clears it. Full suite runs green repeatedly (100 passed, 1 skipped).